### PR TITLE
chore: update vue-jsx-vapor to 3.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "volar-service-typescript": "^0.0.64",
     "vscode-uri": "^3.1.0",
     "vue": "3.6.0-alpha.2",
-    "vue-jsx-vapor": "^3.0.0"
+    "vue-jsx-vapor": "^3.1.0"
   },
   "pnpm": {
     "overrides": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -171,8 +171,8 @@ importers:
         specifier: 3.6.0-alpha.2
         version: 3.6.0-alpha.2(typescript@5.9.2)
       vue-jsx-vapor:
-        specifier: ^3.0.0
-        version: 3.0.0(@nuxt/kit@3.17.6(magicast@0.3.5))(@nuxt/schema@3.17.6)(esbuild@0.25.9)(rolldown-vite@7.0.9(@types/node@22.18.1)(esbuild@0.25.9)(jiti@2.5.1)(sass@1.83.4)(terser@5.39.0)(tsx@4.19.2)(yaml@2.8.1))(rollup@4.50.0)(typescript@5.9.2)(vue@3.6.0-alpha.2(typescript@5.9.2))
+        specifier: ^3.1.0
+        version: 3.1.3(@nuxt/kit@3.17.6(magicast@0.3.5))(@nuxt/schema@3.17.6)(esbuild@0.25.9)(rolldown-vite@7.0.9(@types/node@22.18.1)(esbuild@0.25.9)(jiti@2.5.1)(sass@1.83.4)(terser@5.39.0)(tsx@4.19.2)(yaml@2.8.1))(rollup@4.50.0)(typescript@5.9.2)(vue@3.6.0-alpha.2(typescript@5.9.2))
 
 packages:
 
@@ -190,79 +190,17 @@ packages:
     resolution: {integrity: sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/code-frame@7.27.1':
-    resolution: {integrity: sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/code-frame@8.0.0-beta.2':
     resolution: {integrity: sha512-AKiipLsA7UE3vLjLNxBTsAbU39IkC34a7bAPBerVL/SbF71OO//3hxvWoUgYx44rYTj5deeUbuYdttip8dxHLQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
-
-  '@babel/compat-data@7.28.4':
-    resolution: {integrity: sha512-YsmSKC29MJwf0gF8Rjjrg5LQCmyh+j/nD8/eP7f+BeoQTKYqs9RoWbjGOdy0+1Ekr68RJZMUOPVQaQisnIo4Rw==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/core@7.28.4':
-    resolution: {integrity: sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/generator@7.28.3':
-    resolution: {integrity: sha512-3lSpxGgvnmZznmBkCRnVREPUFJv2wrv9iAoFDvADJc0ypmdOxdUtcLeBgBJ6zE0PMeTKnxeQzyk0xTBq4Ep7zw==}
-    engines: {node: '>=6.9.0'}
 
   '@babel/generator@8.0.0-beta.2':
     resolution: {integrity: sha512-b3ze1JfFSg7OLcT5nfqpWa9PJ1FjOZNvzVk5SI8c5xU4QgTqal06w295yOOZ3SHYUWZq4d/KlvXAwJH+wOOxrQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
 
-  '@babel/helper-annotate-as-pure@7.27.3':
-    resolution: {integrity: sha512-fXSwMQqitTGeHLBC08Eq5yXz2m37E4pJX1qAU1+2cNedz/ifv/bVXft90VeSav5nFO61EcNgwr0aJxbyPaWBPg==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helper-compilation-targets@7.27.2':
-    resolution: {integrity: sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helper-create-class-features-plugin@7.28.3':
-    resolution: {integrity: sha512-V9f6ZFIYSLNEbuGA/92uOvYsGCJNsuA8ESZ4ldc09bWk/j8H8TKiPw8Mk1eG6olpnO0ALHJmYfZvF4MEE4gajg==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-
   '@babel/helper-globals@8.0.0-beta.2':
     resolution: {integrity: sha512-9QeCOLSgIZYgNb8JvEyHquCqKeI5cMoUagtsmyTAkZ/KKjFT2ilp2hIhimuY6P0SAfj93ukZSAyEEaadjjG8ZQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
-
-  '@babel/helper-member-expression-to-functions@7.27.1':
-    resolution: {integrity: sha512-E5chM8eWjTp/aNoVpcbfM7mLxu9XGLWYise2eBKGQomAk/Mb4XoxyqXTZbuTohbsl8EKqdlMhnDI2CCLfcs9wA==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helper-module-imports@7.27.1':
-    resolution: {integrity: sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helper-module-transforms@7.28.3':
-    resolution: {integrity: sha512-gytXUbs8k2sXS9PnQptz5o0QnpLL51SwASIORY6XaBKF88nsOT0Zw9szLqlSGQDP/4TljBAD5y98p2U1fqkdsw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-
-  '@babel/helper-optimise-call-expression@7.27.1':
-    resolution: {integrity: sha512-URMGH08NzYFhubNSGJrpUEphGKQwMQYBySzat5cAByY1/YgIRkULnIy3tAMeszlL/so2HbeilYloUmSpd7GdVw==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helper-plugin-utils@7.27.1':
-    resolution: {integrity: sha512-1gn1Up5YXka3YYAHGKpbideQ5Yjf1tDa9qYcgysz+cNCXukyLl6DjPXhD3VRwSb8c0J9tA4b2+rHEZtc6R0tlw==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helper-replace-supers@7.27.1':
-    resolution: {integrity: sha512-7EHz6qDZc8RYS5ElPoShMheWvEgERonFCs7IAonWLLUTXW59DP14bCZt89/GKyreYn8g3S83m21FelHKbeDCKA==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-
-  '@babel/helper-skip-transparent-expression-wrappers@7.27.1':
-    resolution: {integrity: sha512-Tub4ZKEXqbPjXgWLl2+3JpQAYBJ8+ikpQ2Ocj/q/r0LwE3UhENh7EUabyHjz2kCEsrRY83ew2DQdHluuiDQFzg==}
-    engines: {node: '>=6.9.0'}
 
   '@babel/helper-string-parser@7.27.1':
     resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
@@ -288,14 +226,6 @@ packages:
     resolution: {integrity: sha512-n5STLJIc4loOeI2G+mMZwYIiztQWZdy+3du0cspVWoUjZ4AgkCIld4XcY0jJPgLImStacvJKCO6qCf0UBMpETw==}
     engines: {node: ^20.19.0 || >=22.12.0}
 
-  '@babel/helper-validator-option@7.27.1':
-    resolution: {integrity: sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helpers@7.28.4':
-    resolution: {integrity: sha512-HFN59MmQXGHVyYadKLVumYsA9dBFun/ldYxipEjzA4196jpLZd8UjEEBLkbEkvfYreDqJhZxYAWFPtrfhNpj4w==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/parser@7.27.7':
     resolution: {integrity: sha512-qnzXzDXdr/po3bOTbTIQZ7+TxNKxpkN5IifVLXS+r7qwynkZfPyjZfE7hCXbo7IoO9TNcSyibgONsf2HauUd3Q==}
     engines: {node: '>=6.0.0'}
@@ -315,28 +245,6 @@ packages:
     resolution: {integrity: sha512-91A5GVa6ROgyF1uzDvGJlscf9tktIrXS4ohp8cnW22gwX1ERMw9m9KzdtoFgfdzt9rmSXKYtjwHhh5samc4Pdg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
-
-  '@babel/plugin-syntax-jsx@7.27.1':
-    resolution: {integrity: sha512-y8YTNIeKoyhGd9O0Jiyzyyqk8gdjnumGTQPsz0xOZOQ2RmkVJeZ1vmmfIvFEKqucBG6axJGBZDE/7iI5suUI/w==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/plugin-syntax-typescript@7.27.1':
-    resolution: {integrity: sha512-xfYCBMxveHrRMnAWl1ZlPXOZjzkN82THFvLhQhFXFt81Z5HnN+EtUkZhv/zcKpmT3fzmWZB0ywiBrbC3vogbwQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/plugin-transform-typescript@7.28.0':
-    resolution: {integrity: sha512-4AEiDEBPIZvLQaWlc9liCavE0xRM0dNca41WtBeM3jgFptfUOSG9z0uteLhq6+3rq+WB6jIvUwKDTpXEHPJ2Vg==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/template@7.27.2':
-    resolution: {integrity: sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==}
-    engines: {node: '>=6.9.0'}
 
   '@babel/template@8.0.0-beta.2':
     resolution: {integrity: sha512-2Vl0vsnqYOC69nAgn+3tQ0KkbjJeg+2j1/pRB9ptg6z+EiJCCSbSSupaHdU+SOlFLJOROzEv4NinwOBIkxS+ug==}
@@ -846,8 +754,8 @@ packages:
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
 
-  '@napi-rs/wasm-runtime@1.0.7':
-    resolution: {integrity: sha512-SeDnOO0Tk7Okiq6DbXmmBODgOAb9dp9gjlphokTUxmt8U3liIP1ZsozBahH69j/RJv+Rfs6IwUKHTgQYJ/HBAw==}
+  '@napi-rs/wasm-runtime@1.1.0':
+    resolution: {integrity: sha512-Fq6DJW+Bb5jaWE69/qOE0D1TUN9+6uWhCeZpdnSBk14pjLcCWR7Q8n49PTSPHazM37JqrsdpEthXy2xn6jWWiA==}
 
   '@netlify/blobs@9.1.2':
     resolution: {integrity: sha512-7dMjExSH4zj4ShvLem49mE3mf0K171Tx2pV4WDWhJbRUWW3SJIR2qntz0LvUGS97N5HO1SmnzrgWUhEXCsApiw==}
@@ -1649,84 +1557,84 @@ packages:
   '@volar/typescript@2.4.23':
     resolution: {integrity: sha512-lAB5zJghWxVPqfcStmAP1ZqQacMpe90UrP5RJ3arDyrhy4aCUQqmxPPLB2PWDKugvylmO41ljK7vZ+t6INMTag==}
 
-  '@vue-jsx-vapor/compiler-rs-android-arm-eabi@3.0.0':
-    resolution: {integrity: sha512-pY15CC+zQe5xrjZbVM0nRh/OuJZWzajW0XyF6fOMcexGbW79ocVGCw6LMxyI1HmeTbNFVCRSD1yfKrMwtw8cYg==}
+  '@vue-jsx-vapor/compiler-rs-android-arm-eabi@3.1.3':
+    resolution: {integrity: sha512-k6VsBoTI3Ne0Y0cCzqyoioUJYbLqDKp6KHSix7e7C+6b4zU5tYBmeCMeFpHXTQQjP/F00RMmB09iGhJ2UHa/iA==}
     cpu: [arm]
     os: [android]
 
-  '@vue-jsx-vapor/compiler-rs-android-arm64@3.0.0':
-    resolution: {integrity: sha512-5IPYSCb+LF4denDwcCVKOdtiwtl7sDMzEXJvUFEY1mO0eSn2Fud0lNfc0SHqFwnW8HofAy1wo2mAu22T0YnogA==}
+  '@vue-jsx-vapor/compiler-rs-android-arm64@3.1.3':
+    resolution: {integrity: sha512-IZvea4tlTcm/wO9N1SK2Cy+Egh2AHIUYcIAK/It7IO2+INLjWIy4jgIBR/2SXRPUpiKJXuAi5S52wdwBcGBkTA==}
     cpu: [arm64]
     os: [android]
 
-  '@vue-jsx-vapor/compiler-rs-darwin-arm64@3.0.0':
-    resolution: {integrity: sha512-yCeb7/AiNuAvhHxPwEoafxAYM4LhIOzeX2NJp2ZuCMXxe7b7KGY4e999rmFmrQKdAvdG/QrQx+ZSy0FyQqdsMg==}
+  '@vue-jsx-vapor/compiler-rs-darwin-arm64@3.1.3':
+    resolution: {integrity: sha512-KsGBg3HN+1dAjMpe9JVljmAkmNPuNGsy4cP4VC0qPGYKDGGq/Ku3BGF49h22w9M7LeS6l8w7qbfEg9uoE2Yefw==}
     cpu: [arm64]
     os: [darwin]
 
-  '@vue-jsx-vapor/compiler-rs-darwin-x64@3.0.0':
-    resolution: {integrity: sha512-E2ajDiO2y6hMe4Bo0QculzldnNH8+tcTncBgxFeaY30TSfNHY8ZFYq4pGZqbeIXJk7/MbaKScj/FiYM7ceSa4Q==}
+  '@vue-jsx-vapor/compiler-rs-darwin-x64@3.1.3':
+    resolution: {integrity: sha512-C1XlcbGW32hImbVXz2sIVGh8S82/M+3P0mMcZFkS+d6L/06iQcpN2fm/qMMMF/Bw0/udASo3p513jelIn5QFOw==}
     cpu: [x64]
     os: [darwin]
 
-  '@vue-jsx-vapor/compiler-rs-freebsd-x64@3.0.0':
-    resolution: {integrity: sha512-ml+Ua/h39TNAw+UQBJJvoznlVcp4GZs6eq5LBw53edxZKa3hoBZFZyQBqHFgL5zIE/s01dYXWJ79IdfPle0SZQ==}
+  '@vue-jsx-vapor/compiler-rs-freebsd-x64@3.1.3':
+    resolution: {integrity: sha512-XIuOpzYJMd749LRc9S4HCMrdJAbqIRgPn7lGwyHdkPgfYgOoUpkm9WY85DvMkCz96+y7QL1y1FpytI0CtNWReg==}
     cpu: [x64]
     os: [freebsd]
 
-  '@vue-jsx-vapor/compiler-rs-linux-arm-gnueabihf@3.0.0':
-    resolution: {integrity: sha512-uW5sJrvBkkX8Mkum+xMuNEjawjto+3gEY5NKqBSyW8gB2ctRVv7axy1NP8mgcJM0QG9aIJpfE5P8dSmfJbXbmg==}
+  '@vue-jsx-vapor/compiler-rs-linux-arm-gnueabihf@3.1.3':
+    resolution: {integrity: sha512-RR6d2yAG5FyV8A8Bwe3z2hvhqKAo6NH3tYef3Ey1HbbqD3tE47kz7xmf6Ys6BbsgdZvJGepQYW7lgSF783EXwA==}
     cpu: [arm]
     os: [linux]
 
-  '@vue-jsx-vapor/compiler-rs-linux-arm64-gnu@3.0.0':
-    resolution: {integrity: sha512-gP6mb0ZYNA5XbjJvFdzWK6KhfG/KQowS1Notm6MvwRp7wjoCEjmsG0Qam277HcS5d80VXvVa9hOcMthFLBShyw==}
+  '@vue-jsx-vapor/compiler-rs-linux-arm64-gnu@3.1.3':
+    resolution: {integrity: sha512-SpBVI7vk2o7J4VBWzLSW6HW8midCf/UFpCM/7URrhZvWrG9Yr+nCndDWunmO1cu5P0DYDbxeAEcE/wvooX1Wjg==}
     cpu: [arm64]
     os: [linux]
 
-  '@vue-jsx-vapor/compiler-rs-linux-arm64-musl@3.0.0':
-    resolution: {integrity: sha512-l4YBiB2WamCWpt+8UG9HchIov8DaO7iOKehD300k/IySlhLe3RpOHEm55iAZGfpCbANLtSz8SQoIFxOBw785FQ==}
+  '@vue-jsx-vapor/compiler-rs-linux-arm64-musl@3.1.3':
+    resolution: {integrity: sha512-7Kgxuh709tzps4aAK+UyDGHEkYbuuSMZ5+nPoARVeeO3Xgl7DWRlfBmueOWvkVw60OH2y07xmTFvBo7pqGrhfg==}
     cpu: [arm64]
     os: [linux]
 
-  '@vue-jsx-vapor/compiler-rs-linux-x64-gnu@3.0.0':
-    resolution: {integrity: sha512-85OYIwd3ILDI7kGw15bQWEZDZIJ0wUsWaXBuPrrEBGBwmZz/oiuUZmsOyw2mfl+SZpSRq3GQrgR349vsnx+UyQ==}
+  '@vue-jsx-vapor/compiler-rs-linux-x64-gnu@3.1.3':
+    resolution: {integrity: sha512-Tv3Zqu4MFo9ssafeYMZOqUCa3NlVJP5GwKZpOHNaZx0791p/1ODELpNDNhuf5YBYExxv1iC4GPTF/hn4qLuBxA==}
     cpu: [x64]
     os: [linux]
 
-  '@vue-jsx-vapor/compiler-rs-linux-x64-musl@3.0.0':
-    resolution: {integrity: sha512-9VR3xn6xsUUNB+NJ2UUfxmBt/48b2wQuoLh2q8xUrYeKvR3QymYT7TBplOLucU+/O9NWCTpeUP5CqzPuB5JREg==}
+  '@vue-jsx-vapor/compiler-rs-linux-x64-musl@3.1.3':
+    resolution: {integrity: sha512-b+PpE6eQndgBd7ddasCeTH+YlVMazPDy1UHSDzXcBoN78F/424el1YcISY4lfBrRF9OIt0dQrZDK3CCoyug/qA==}
     cpu: [x64]
     os: [linux]
 
-  '@vue-jsx-vapor/compiler-rs-wasm32-wasi@3.0.0':
-    resolution: {integrity: sha512-qbGNwPc9H7CO1rhHXPYnZ1ghWDOcPuboF1Rec21N3eTKduj/G91cZOtEQqJ7DfnEOIIMVjOsQ98SQP5grSIdkw==}
+  '@vue-jsx-vapor/compiler-rs-wasm32-wasi@3.1.3':
+    resolution: {integrity: sha512-a365jMlHrwkU5QQ+V7X4xp9B0zaWQujMhHwlKTs/qaAFGMq0Xfbk5JkyAnhNyENf3pHMRSPMNtpv90hFUnQ6Yw==}
     engines: {node: '>=14.0.0'}
     cpu: [wasm32]
 
-  '@vue-jsx-vapor/compiler-rs-win32-arm64-msvc@3.0.0':
-    resolution: {integrity: sha512-g2LFDVrXcfDRfqFBrRfIfIYaKJWwCPAcGrxhRfuPFHZ5bOWhuF1eDXKy1RIgnxF7NsHqBKzxBQ1iOdJsLg89cw==}
+  '@vue-jsx-vapor/compiler-rs-win32-arm64-msvc@3.1.3':
+    resolution: {integrity: sha512-bdERYcJE0rQgiWqxewqQplCo/l43N59AG2mOLMZZMb9LMuZDSNHXi4nuYbmzwzYlsaEuVDME/JGoO2mG32XEdw==}
     cpu: [arm64]
     os: [win32]
 
-  '@vue-jsx-vapor/compiler-rs-win32-ia32-msvc@3.0.0':
-    resolution: {integrity: sha512-ZyvNbGtwBhmFleiCodRClsbLZk7biAvo3cJ+mAeItj8GaSithDoDaaPWSCJkL5aUeeuqA/R9fE4mrD19YyhNXQ==}
+  '@vue-jsx-vapor/compiler-rs-win32-ia32-msvc@3.1.3':
+    resolution: {integrity: sha512-iJHYuW3vgg8NEXL7fRPEzwY6azVcYCw+3LgBTfmDhkdCaD5pxXzyNy3TdnE9tHBMBKOkWy8kRL/Sj2yh8otXlA==}
     cpu: [ia32]
     os: [win32]
 
-  '@vue-jsx-vapor/compiler-rs-win32-x64-msvc@3.0.0':
-    resolution: {integrity: sha512-Lv60AzE+NbX+dZK5bkaTFd9Bhe6mbCB1ALCzY9WzcKbiSHO6svy3XtydYh7dPwsXmSlG0tI+SMVe9/J0vR6YCw==}
+  '@vue-jsx-vapor/compiler-rs-win32-x64-msvc@3.1.3':
+    resolution: {integrity: sha512-Q4LqfrlK9fkujOpJXJz5xM8Puw6lfd4S1ZF8IWCkP9oAwzM5XQZWXErcE2cAaTA+RG620vb5es16f53rX0XT/g==}
     cpu: [x64]
     os: [win32]
 
-  '@vue-jsx-vapor/compiler-rs@3.0.0':
-    resolution: {integrity: sha512-vChHjeT2n1wgIOUi9erWt3zp0+teBcnw1XgBxQUp8bpCDohANQi09RzDwNpP5iTdZnKhegoOO9mvNYYyqMxBIw==}
+  '@vue-jsx-vapor/compiler-rs@3.1.3':
+    resolution: {integrity: sha512-bIlUPbXQ0cqiNeT6gRc6enPHRHKEPtruuaKG15o6VRp6AF0QX1XmK/KbYE/sO/5Wob37dyWKzcsS0JvF2Dec+A==}
 
   '@vue-jsx-vapor/eslint@2.6.4':
     resolution: {integrity: sha512-TRhixql4g3KISvwQDajh/gPnR8gv5JmU1Zz6E+vI4rvTw7Z3SmaiDC2rPIUqXmv5/2iiZiEuwINHjfqduOKp0Q==}
 
-  '@vue-jsx-vapor/macros@3.0.0':
-    resolution: {integrity: sha512-NESGzcBn7zfuUtgQtxuETJistNalQfkbAKDhKi46W22YGQatVxy/MfpT+ggrEySwpfCTSZGEiTIickTbVGRU1w==}
+  '@vue-jsx-vapor/macros@3.1.3':
+    resolution: {integrity: sha512-oamnEFqWOJUT3QbJoHeoDqfsxjf7t/2OoC2pAxIJFbEuJ3jgIQz5p5Y1xUxB0qlzckU/Lbs5s6fY9esJLwBTkA==}
     peerDependencies:
       '@nuxt/kit': ^3
       '@nuxt/schema': ^3
@@ -1748,8 +1656,8 @@ packages:
       webpack:
         optional: true
 
-  '@vue-jsx-vapor/runtime@3.0.0':
-    resolution: {integrity: sha512-nCZSDU9g/LQEgNagbeCoNwrGMXgxAOcn/g8kqylLBTGgueHwTTKfTzztzIHRFyHadyIA0f2EFQ1HSD4jG5Xe5A==}
+  '@vue-jsx-vapor/runtime@3.1.3':
+    resolution: {integrity: sha512-9j9g0x7btWmgfg+UNQ2CuSkgLe6R4lmobwM8VgZJoe5oJ4EAqZ7YItZmYOaI/rUODZsPv9CLKD+kGohgkY3OMw==}
     peerDependencies:
       vue: ^3.6.0-alpha.2
 
@@ -1779,10 +1687,6 @@ packages:
     resolution: {integrity: sha512-v1UuDnnSfL/NNjASqHa4OIArOG4v3+Lh6LW5bAAaxv7b3SLP0qhjp46S5L3L7sy+ogCAwsIKEWbCPC+PXyijMg==}
     engines: {node: '>=20.19.0'}
 
-  '@vue-macros/jsx-directive@3.1.1':
-    resolution: {integrity: sha512-QprN9ejChBbwKAFh/E3KW4X/T72wFjJu4wNe4G1+Te5j1TngqvR8ap4DSguJquqdgvO3Yh4acRWcqXrLi0YNbg==}
-    engines: {node: '>=20.19.0'}
-
   '@vue-macros/short-bind@3.1.1':
     resolution: {integrity: sha512-pFd0swiQVDTmrnAn2Lyma2iF1YNGhSouRKAlaJV4PlFHsV8/D8U1s8nIvMX0i1Vyuj5Q4RFzMpQVjKPH8zmk6w==}
     engines: {node: '>=20.19.0'}
@@ -1800,22 +1704,6 @@ packages:
       vue-tsc:
         optional: true
 
-  '@vue/babel-helper-vue-transform-on@1.5.0':
-    resolution: {integrity: sha512-0dAYkerNhhHutHZ34JtTl2czVQHUNWv6xEbkdF5W+Yrv5pCWsqjeORdOgbtW2I9gWlt+wBmVn+ttqN9ZxR5tzA==}
-
-  '@vue/babel-plugin-jsx@1.5.0':
-    resolution: {integrity: sha512-mneBhw1oOqCd2247O0Yw/mRwC9jIGACAJUlawkmMBiNmL4dGA2eMzuNZVNqOUfYTa6vqmND4CtOPzmEEEqLKFw==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
-
-  '@vue/babel-plugin-resolve-type@1.5.0':
-    resolution: {integrity: sha512-Wm/60o+53JwJODm4Knz47dxJnLDJ9FnKnGZJbUUf8nQRAtt6P+undLUAVU3Ha33LxOJe6IPoifRQ6F/0RrU31w==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
   '@vue/compiler-core@3.5.17':
     resolution: {integrity: sha512-Xe+AittLbAyV0pabcN7cP7/BenRBNcteM4aSDCtRvGw0d9OL+HG1u/XHLY/kt1q4fyMeZYXyIYrsHuPSiDPosA==}
 
@@ -1824,6 +1712,9 @@ packages:
 
   '@vue/compiler-core@3.6.0-alpha.2':
     resolution: {integrity: sha512-2aPvrCWKKhKKU4TaX6N6+cY4LcLIlIc+tcxJHw029mZr7KGb/w+98UxU9o3mYe/CLo5c5v8ps4IlE/Tm4H/eZA==}
+
+  '@vue/compiler-core@3.6.0-alpha.7':
+    resolution: {integrity: sha512-/Vbduf1Sk6DpJkgyezTPPiULaFeMDxCwXpDvDiIjOPDarqtn7oplLpCgxJgMhdKVJVno22r1xqAEXxR+HDWQkw==}
 
   '@vue/compiler-dom@3.5.17':
     resolution: {integrity: sha512-+2UgfLKoaNLhgfhV5Ihnk6wB4ljyW1/7wUIog2puUqajiC29Lp5R/IKDdkebh9jTbTogTbsgB+OY9cEWzG95JQ==}
@@ -1834,6 +1725,9 @@ packages:
   '@vue/compiler-dom@3.6.0-alpha.2':
     resolution: {integrity: sha512-WHFo0z5QXXkBQk65NPrze1RO4RG6vAHcMudRG604zs2VsMkJPXBL5CAFcae3R6aoU3wwbIYHkklbMOelegS90w==}
 
+  '@vue/compiler-dom@3.6.0-alpha.7':
+    resolution: {integrity: sha512-3cNYa1sHJLqoBJrzhcjUrv+Us4mH54IhmTiYwjZP0Ov8anMpwdW5Bu+0LVvRLYpNoilW9OdTZyo7+xh8p1Jn3Q==}
+
   '@vue/compiler-sfc@3.5.17':
     resolution: {integrity: sha512-rQQxbRJMgTqwRugtjw0cnyQv9cP4/4BxWfTdRBkqsTfLOHWykLzbOc3C4GGzAmdMDxhzU/1Ija5bTjMVrddqww==}
 
@@ -1842,6 +1736,9 @@ packages:
 
   '@vue/compiler-sfc@3.6.0-alpha.2':
     resolution: {integrity: sha512-QFwY1M5lYTo6Qt0rSQKXEp9aZngaKtT4WRlITAuioNeFoK5Y5stElr6sw2dopsaPzjbAJftDbQ7MgtMjOZ9XQg==}
+
+  '@vue/compiler-sfc@3.6.0-alpha.7':
+    resolution: {integrity: sha512-nDohrY7Qb7/HJNVAuXpA/jsnk+VX6VbDmtLA4zFhK7OaqcmaxYCaTuQzfRN/DRBRB2tEb/cNaiS8ArZ/3ZtloQ==}
 
   '@vue/compiler-ssr@3.5.17':
     resolution: {integrity: sha512-hkDbA0Q20ZzGgpj5uZjb9rBzQtIHLS78mMilwrlpWk2Ep37DYntUz0PonQ6kr113vfOEdM+zTBuJDaceNIW0tQ==}
@@ -1852,8 +1749,14 @@ packages:
   '@vue/compiler-ssr@3.6.0-alpha.2':
     resolution: {integrity: sha512-BtP+A4xL7QSCf/P1eOvJw9XG1wojK3nqjJXSABcwXeIv0SJgBpi4CZ/obVUPAiUWMmdJDV3bdSwqQtkiXqOmug==}
 
+  '@vue/compiler-ssr@3.6.0-alpha.7':
+    resolution: {integrity: sha512-OHTUffG2w255imuw4BrIyjNwzIfFi0ywhwR1ZLvE5mjoQq5cWDZgVz7/t51aNZJncx/BQ6bnR5+rppLocYuF2Q==}
+
   '@vue/compiler-vapor@3.6.0-alpha.2':
     resolution: {integrity: sha512-/qmhrcOrVmBsZiQEpDMH5coH/hx7v1uflKCXDcvWhl7XaPfNWBeVwIndU/s/8mtOz+5nuCZrGtbqozXc4tfQzw==}
+
+  '@vue/compiler-vapor@3.6.0-alpha.7':
+    resolution: {integrity: sha512-d8CMxs1lMRw1jPanQgZhaRgXh/iX6czh4FHMHDTDXJYBp2Rr0R9yEV7N8hoiRjDf4TjxvlTFCuuuYXytOLpZ8g==}
 
   '@vue/compiler-vue2@2.7.16':
     resolution: {integrity: sha512-qYC3Psj9S/mfu9uVi5WvNZIzq+xnXMhOwbTFKKDD7b1lhpnn71jXSFdTQ+WsIEk0ONCd7VV2IMm7ONl6tbQ86A==}
@@ -1874,20 +1777,11 @@ packages:
       typescript:
         optional: true
 
-  '@vue/reactivity@3.5.25':
-    resolution: {integrity: sha512-5xfAypCQepv4Jog1U4zn8cZIcbKKFka3AgWHEFQeK65OW+Ys4XybP6z2kKgws4YB43KGpqp5D/K3go2UPPunLA==}
-
   '@vue/reactivity@3.6.0-alpha.2':
     resolution: {integrity: sha512-dqCEZHz7dy5u0fZV1ILObnH2YCA+I6UHuOt7PLGb1NBEAAUbO251nOK9OfecZEEPsvMJRl3P9rNqdJmAvIcHTg==}
 
-  '@vue/runtime-core@3.5.25':
-    resolution: {integrity: sha512-Z751v203YWwYzy460bzsYQISDfPjHTl+6Zzwo/a3CsAf+0ccEjQ8c+0CdX1WsumRTHeywvyUFtW6KvNukT/smA==}
-
   '@vue/runtime-core@3.6.0-alpha.2':
     resolution: {integrity: sha512-OPEIqs/q2rTZWTJm8VVSsI9B2OgsKdtprKEqzw3L74tBGDwNRleCGxGxu2T3LUpPlOtQFkSCZTIh1M52/6PG0w==}
-
-  '@vue/runtime-dom@3.5.25':
-    resolution: {integrity: sha512-a4WrkYFbb19i9pjkz38zJBg8wa/rboNERq3+hRRb0dHiJh13c+6kAbgqCPfMaJ2gg4weWD3APZswASOfmKwamA==}
 
   '@vue/runtime-dom@3.6.0-alpha.2':
     resolution: {integrity: sha512-oYrpDYpbRqv/pgqM1SJEN7w9oahCjj6Txatz7McMJ++CX0WyFqAChi3Zvxr06Vrte+OCWA86t6Ot8K+mKV0QAA==}
@@ -1896,11 +1790,6 @@ packages:
     resolution: {integrity: sha512-UdGN6tcXIMTD/OFR7qI8V+ID4lji7K5A90i68OjiCr8nevtGxjfYPB3Lz5Lg7S6sckPCnFTECHExzWOmE7aV0A==}
     peerDependencies:
       '@vue/runtime-dom': 3.6.0-alpha.2
-
-  '@vue/server-renderer@3.5.25':
-    resolution: {integrity: sha512-UJaXR54vMG61i8XNIzTSf2Q7MOqZHpp8+x3XLGtE3+fL+nQd+k7O5+X3D/uWrnQXOdMw5VPih+Uremcw+u1woQ==}
-    peerDependencies:
-      vue: 3.5.25
 
   '@vue/server-renderer@3.6.0-alpha.2':
     resolution: {integrity: sha512-Zw+fX/FlRqfwzrv5EmCyLBN5bOZWsRo3SnxQKqPl1yA5xGDe+FIe9cjII/X7hlFdC9Vb4lmQBvOQSnTeTj8ygA==}
@@ -1915,6 +1804,9 @@ packages:
 
   '@vue/shared@3.6.0-alpha.2':
     resolution: {integrity: sha512-/tviorcvTBm63BIg/oEpU+tuU3NUrLkWWPrljCH//2vHwc/RJZ7wxq6vPLWfTcuSc82uxDWZXDTKxUjN8/JmGQ==}
+
+  '@vue/shared@3.6.0-alpha.7':
+    resolution: {integrity: sha512-+4M8SiMOT68B7PCIBWjFDaAVjfAzxBSU7Ia3mW3W0R9iyYjbm3KBeHjBmnvYyAagq9ql3VWfz28mPF6HMvT8RA==}
 
   '@whatwg-node/disposablestack@0.0.6':
     resolution: {integrity: sha512-LOtTn+JgJvX8WfBVJtF08TGrdjuFzGJc4mkP8EdDI8ADbvO7kiexYep1o8dwnt0okb0jYclCDXF13xU7Ge4zSw==}
@@ -2108,11 +2000,6 @@ packages:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
 
-  browserslist@4.25.4:
-    resolution: {integrity: sha512-4jYpcjabC606xJ3kw2QwGEZKX0Aw7sgQdZCvIK9dhVSPh76BKo+C+btT1RRofH7B+8iNpEbgGNVWiLki5q93yg==}
-    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
-    hasBin: true
-
   buffer-crc32@1.0.0:
     resolution: {integrity: sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==}
     engines: {node: '>=8.0.0'}
@@ -2173,9 +2060,6 @@ packages:
   callsites@3.1.0:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
-
-  caniuse-lite@1.0.30001741:
-    resolution: {integrity: sha512-QGUGitqsc8ARjLdgAfxETDhRbJ0REsP6O3I96TAth/mVjh2cYzN2u+3AzPP3aVSm2FehEItaJw1xd+IGBXWeSw==}
 
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
@@ -2351,9 +2235,6 @@ packages:
     resolution: {integrity: sha512-TbsINLp48XeMXR8EvGjTnKGsZqBemisPoyWESlpRyR8lif0lcwzqz+NMtYSj1ooF/WYjSuu7wX0CtdeeMEQAmA==}
     engines: {node: '>=18'}
     hasBin: true
-
-  convert-source-map@2.0.0:
-    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
   cookie-es@1.2.2:
     resolution: {integrity: sha512-+W7VmiVINB+ywl1HGXJXmrqkOhpKrIiVZV6tQuV54ZyQC7MMuBt81Vc336GMLoHBq5hV/F9eXgt5Mnx0Rha5Fg==}
@@ -2552,9 +2433,6 @@ packages:
 
   effect@3.16.12:
     resolution: {integrity: sha512-N39iBk0K71F9nb442TLbTkjl24FLUzuvx2i1I2RsEAQsdAdUTuUoW0vlfUXgkMTUOnYqKnWcFfqw4hK4Pw27hg==}
-
-  electron-to-chromium@1.5.214:
-    resolution: {integrity: sha512-TpvUNdha+X3ybfU78NoQatKvQEm1oq3lf2QbnmCEdw+Bd9RuIAY+hJTvq1avzHM0f7EJfnH3vbCnbzKzisc/9Q==}
 
   emoji-regex@10.4.0:
     resolution: {integrity: sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw==}
@@ -2822,10 +2700,6 @@ packages:
 
   generic-names@4.0.0:
     resolution: {integrity: sha512-ySFolZQfw9FoDb3ed9d80Cm9f0+r7qj+HJkWjeD9RBfpxEVTlVhol+gvaQB/78WbwYfbnNh8nWHHBSlg072y6A==}
-
-  gensync@1.0.0-beta.2:
-    resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
-    engines: {node: '>=6.9.0'}
 
   get-caller-file@2.0.5:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
@@ -3169,11 +3043,6 @@ packages:
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
 
-  json5@2.2.3:
-    resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
-    engines: {node: '>=6'}
-    hasBin: true
-
   jsonc-parser@3.3.1:
     resolution: {integrity: sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==}
 
@@ -3336,9 +3205,6 @@ packages:
 
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
-
-  lru-cache@5.1.1:
-    resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
   lru-cache@6.0.0:
     resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
@@ -3574,9 +3440,6 @@ packages:
 
   node-mock-http@1.0.3:
     resolution: {integrity: sha512-jN8dK25fsfnMrVsEhluUTPkBFY+6ybu7jSB1n+ri/vOGjJxU8J9CZhpSGkHXSkFjtUhbmoncG/YG9ta5Ludqog==}
-
-  node-releases@2.0.20:
-    resolution: {integrity: sha512-7gK6zSXEH6neM212JgfYFXe+GmZQM+fia5SsusuBIUgnPheLFBmIPhtFoAQRj8/7wASYQnbDlHPVwY0BefoFgA==}
 
   nopt@8.1.0:
     resolution: {integrity: sha512-ieGu42u/Qsa4TFktmaKEwM6MQH0pOWnaB3htzh0JRtx84+Mebc0cbZYN5bC+6WTZ4+77xrL9Pn5m7CV6VIkV7A==}
@@ -4084,10 +3947,6 @@ packages:
   scule@1.3.0:
     resolution: {integrity: sha512-6FtHJEvt+pVMIB9IBY+IcCJ6Z5f1iQnytgyfKMhDKgmzYG+TeH/wx1y3l27rshSbLiSanrR9ffZDrEsmjlQF2g==}
 
-  semver@6.3.1:
-    resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
-    hasBin: true
-
   semver@7.5.4:
     resolution: {integrity: sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==}
     engines: {node: '>=10'}
@@ -4544,6 +4403,10 @@ packages:
     resolution: {integrity: sha512-6NCPkv1ClwH+/BGE9QeoTIl09nuiAt0gS28nn1PvYXsGKRwM2TCbFA2QiilmehPDTXIe684k4rZI1yl3A1PCUw==}
     engines: {node: '>=18.12.0'}
 
+  unplugin@2.3.11:
+    resolution: {integrity: sha512-5uKD0nqiYVzlmCRs01Fhs2BdkEgBS3SAVP6ndrBsuK42iC2+JHyxM05Rm9G8+5mkmRtzMZGY8Ct5+mliZxU/Ww==}
+    engines: {node: '>=18.12.0'}
+
   unplugin@2.3.5:
     resolution: {integrity: sha512-RyWSb5AHmGtjjNQ6gIlA67sHOsWpsbWpwDokLwTcejVdOjEkJZh7QKu14J00gDDVSh8kGH4KYC/TNBceXFZhtw==}
     engines: {node: '>=18.12.0'}
@@ -4620,12 +4483,6 @@ packages:
 
   unwasm@0.3.11:
     resolution: {integrity: sha512-Vhp5gb1tusSQw5of/g3Q697srYgMXvwMgXMjcG4ZNga02fDX9coxJ9fAb0Ci38hM2Hv/U1FXRPGgjP2BYqhNoQ==}
-
-  update-browserslist-db@1.1.3:
-    resolution: {integrity: sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==}
-    hasBin: true
-    peerDependencies:
-      browserslist: '>= 4.21.0'
 
   uqr@0.1.2:
     resolution: {integrity: sha512-MJu7ypHq6QasgF5YRTjqscSzQp/W11zoUk6kvmlH+fmWEs63Y0Eib13hYFwAzagRJcVY8WVnlV+eBDUGMJ5IbA==}
@@ -4717,15 +4574,15 @@ packages:
   vue-flow-layout@0.2.0:
     resolution: {integrity: sha512-zKgsWWkXq0xrus7H4Mc+uFs1ESrmdTXlO0YNbR6wMdPaFvosL3fMB8N7uTV308UhGy9UvTrGhIY7mVz9eN+L0Q==}
 
-  vue-jsx-vapor@3.0.0:
-    resolution: {integrity: sha512-oseVqr2UpeUl+WzENHNvdGINXQw+sp6dHt38/s4mMc91H7DDnIeum8kbb54AmovE+mi+eQTCoLNhKN8jNyrEQw==}
+  vue-jsx-vapor@3.1.3:
+    resolution: {integrity: sha512-zgqnEXd6+hSNkZwNCxUSF+sDdpDwXahjLc+JzjpfRhLto7lFKHD0DknIZ/fkD4js369++jsKs60gTSNnuiT5KQ==}
     peerDependencies:
       '@nuxt/kit': ^3
       '@nuxt/schema': ^3
       esbuild: '*'
       rollup: ^3
       vite: '>=3'
-      vue: ^3.6.0-alpha.2
+      vue: ^3
       webpack: ^4 || ^5
     peerDependenciesMeta:
       '@nuxt/kit':
@@ -4745,14 +4602,6 @@ packages:
     resolution: {integrity: sha512-7+iqOueLU7uc9NrMfrzbG8hwMqchfVfSzpVlCMeJQe4pyibqyoifDNbKTZvwxZKDvGkB+PdFeKvnGZMoEb8esg==}
     peerDependencies:
       vue: ^3.0.0
-
-  vue@3.5.25:
-    resolution: {integrity: sha512-YLVdgv2K13WJ6n+kD5owehKtEXwdwXuj2TTyJMsO7pSeKw2bfRNZGjhB7YzrpbMYj5b5QsUebHpOqR3R3ziy/g==}
-    peerDependencies:
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
 
   vue@3.6.0-alpha.2:
     resolution: {integrity: sha512-xn3jwLo6eMqxEKEAW8TWX+KSm7K2jTrNZ5Q3+H5Bu9P3mkoz8w0lUQHrO5WcnSVZfmR7vvw4/5XSYQe2XeDzdw==}
@@ -4818,9 +4667,6 @@ packages:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
     engines: {node: '>=10'}
 
-  yallist@3.1.1:
-    resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
-
   yallist@4.0.0:
     resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
 
@@ -4883,47 +4729,11 @@ snapshots:
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
-  '@babel/code-frame@7.27.1':
-    dependencies:
-      '@babel/helper-validator-identifier': 7.28.5
-      js-tokens: 4.0.0
-      picocolors: 1.1.1
-
   '@babel/code-frame@8.0.0-beta.2':
     dependencies:
       '@babel/helper-validator-identifier': 8.0.0-beta.2
       js-tokens: 8.0.3
       picocolors: 1.1.1
-
-  '@babel/compat-data@7.28.4': {}
-
-  '@babel/core@7.28.4':
-    dependencies:
-      '@babel/code-frame': 7.27.1
-      '@babel/generator': 7.28.3
-      '@babel/helper-compilation-targets': 7.27.2
-      '@babel/helper-module-transforms': 7.28.3(@babel/core@7.28.4)
-      '@babel/helpers': 7.28.4
-      '@babel/parser': 7.28.5
-      '@babel/template': 7.27.2
-      '@babel/traverse': 8.0.0-beta.2
-      '@babel/types': 7.28.5
-      '@jridgewell/remapping': 2.3.5
-      convert-source-map: 2.0.0
-      debug: 4.4.1
-      gensync: 1.0.0-beta.2
-      json5: 2.2.3
-      semver: 6.3.1
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/generator@7.28.3':
-    dependencies:
-      '@babel/parser': 7.28.5
-      '@babel/types': 7.28.5
-      '@jridgewell/gen-mapping': 0.3.12
-      '@jridgewell/trace-mapping': 0.3.29
-      jsesc: 3.1.0
 
   '@babel/generator@8.0.0-beta.2':
     dependencies:
@@ -4934,77 +4744,7 @@ snapshots:
       '@types/jsesc': 2.5.1
       jsesc: 3.1.0
 
-  '@babel/helper-annotate-as-pure@7.27.3':
-    dependencies:
-      '@babel/types': 7.28.5
-
-  '@babel/helper-compilation-targets@7.27.2':
-    dependencies:
-      '@babel/compat-data': 7.28.4
-      '@babel/helper-validator-option': 7.27.1
-      browserslist: 4.25.4
-      lru-cache: 5.1.1
-      semver: 6.3.1
-
-  '@babel/helper-create-class-features-plugin@7.28.3(@babel/core@7.28.4)':
-    dependencies:
-      '@babel/core': 7.28.4
-      '@babel/helper-annotate-as-pure': 7.27.3
-      '@babel/helper-member-expression-to-functions': 7.27.1
-      '@babel/helper-optimise-call-expression': 7.27.1
-      '@babel/helper-replace-supers': 7.27.1(@babel/core@7.28.4)
-      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
-      '@babel/traverse': 8.0.0-beta.2
-      semver: 6.3.1
-    transitivePeerDependencies:
-      - supports-color
-
   '@babel/helper-globals@8.0.0-beta.2': {}
-
-  '@babel/helper-member-expression-to-functions@7.27.1':
-    dependencies:
-      '@babel/traverse': 8.0.0-beta.2
-      '@babel/types': 7.28.5
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/helper-module-imports@7.27.1':
-    dependencies:
-      '@babel/traverse': 8.0.0-beta.2
-      '@babel/types': 7.28.5
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/helper-module-transforms@7.28.3(@babel/core@7.28.4)':
-    dependencies:
-      '@babel/core': 7.28.4
-      '@babel/helper-module-imports': 7.27.1
-      '@babel/helper-validator-identifier': 7.28.5
-      '@babel/traverse': 8.0.0-beta.2
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/helper-optimise-call-expression@7.27.1':
-    dependencies:
-      '@babel/types': 7.28.5
-
-  '@babel/helper-plugin-utils@7.27.1': {}
-
-  '@babel/helper-replace-supers@7.27.1(@babel/core@7.28.4)':
-    dependencies:
-      '@babel/core': 7.28.4
-      '@babel/helper-member-expression-to-functions': 7.27.1
-      '@babel/helper-optimise-call-expression': 7.27.1
-      '@babel/traverse': 8.0.0-beta.2
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/helper-skip-transparent-expression-wrappers@7.27.1':
-    dependencies:
-      '@babel/traverse': 8.0.0-beta.2
-      '@babel/types': 7.28.5
-    transitivePeerDependencies:
-      - supports-color
 
   '@babel/helper-string-parser@7.27.1': {}
 
@@ -5017,13 +4757,6 @@ snapshots:
   '@babel/helper-validator-identifier@7.28.5': {}
 
   '@babel/helper-validator-identifier@8.0.0-beta.2': {}
-
-  '@babel/helper-validator-option@7.27.1': {}
-
-  '@babel/helpers@7.28.4':
-    dependencies:
-      '@babel/template': 7.27.2
-      '@babel/types': 7.28.5
 
   '@babel/parser@7.27.7':
     dependencies:
@@ -5040,33 +4773,6 @@ snapshots:
   '@babel/parser@8.0.0-beta.2':
     dependencies:
       '@babel/types': 8.0.0-beta.2
-
-  '@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.28.4)':
-    dependencies:
-      '@babel/core': 7.28.4
-      '@babel/helper-plugin-utils': 7.27.1
-
-  '@babel/plugin-syntax-typescript@7.27.1(@babel/core@7.28.4)':
-    dependencies:
-      '@babel/core': 7.28.4
-      '@babel/helper-plugin-utils': 7.27.1
-
-  '@babel/plugin-transform-typescript@7.28.0(@babel/core@7.28.4)':
-    dependencies:
-      '@babel/core': 7.28.4
-      '@babel/helper-annotate-as-pure': 7.27.3
-      '@babel/helper-create-class-features-plugin': 7.28.3(@babel/core@7.28.4)
-      '@babel/helper-plugin-utils': 7.27.1
-      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
-      '@babel/plugin-syntax-typescript': 7.27.1(@babel/core@7.28.4)
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/template@7.27.2':
-    dependencies:
-      '@babel/code-frame': 7.27.1
-      '@babel/parser': 7.28.5
-      '@babel/types': 7.28.5
 
   '@babel/template@8.0.0-beta.2':
     dependencies:
@@ -5500,7 +5206,7 @@ snapshots:
       '@tybys/wasm-util': 0.10.0
     optional: true
 
-  '@napi-rs/wasm-runtime@1.0.7':
+  '@napi-rs/wasm-runtime@1.1.0':
     dependencies:
       '@emnapi/core': 1.7.1
       '@emnapi/runtime': 1.7.1
@@ -6377,66 +6083,66 @@ snapshots:
       path-browserify: 1.0.1
       vscode-uri: 3.1.0
 
-  '@vue-jsx-vapor/compiler-rs-android-arm-eabi@3.0.0':
+  '@vue-jsx-vapor/compiler-rs-android-arm-eabi@3.1.3':
     optional: true
 
-  '@vue-jsx-vapor/compiler-rs-android-arm64@3.0.0':
+  '@vue-jsx-vapor/compiler-rs-android-arm64@3.1.3':
     optional: true
 
-  '@vue-jsx-vapor/compiler-rs-darwin-arm64@3.0.0':
+  '@vue-jsx-vapor/compiler-rs-darwin-arm64@3.1.3':
     optional: true
 
-  '@vue-jsx-vapor/compiler-rs-darwin-x64@3.0.0':
+  '@vue-jsx-vapor/compiler-rs-darwin-x64@3.1.3':
     optional: true
 
-  '@vue-jsx-vapor/compiler-rs-freebsd-x64@3.0.0':
+  '@vue-jsx-vapor/compiler-rs-freebsd-x64@3.1.3':
     optional: true
 
-  '@vue-jsx-vapor/compiler-rs-linux-arm-gnueabihf@3.0.0':
+  '@vue-jsx-vapor/compiler-rs-linux-arm-gnueabihf@3.1.3':
     optional: true
 
-  '@vue-jsx-vapor/compiler-rs-linux-arm64-gnu@3.0.0':
+  '@vue-jsx-vapor/compiler-rs-linux-arm64-gnu@3.1.3':
     optional: true
 
-  '@vue-jsx-vapor/compiler-rs-linux-arm64-musl@3.0.0':
+  '@vue-jsx-vapor/compiler-rs-linux-arm64-musl@3.1.3':
     optional: true
 
-  '@vue-jsx-vapor/compiler-rs-linux-x64-gnu@3.0.0':
+  '@vue-jsx-vapor/compiler-rs-linux-x64-gnu@3.1.3':
     optional: true
 
-  '@vue-jsx-vapor/compiler-rs-linux-x64-musl@3.0.0':
+  '@vue-jsx-vapor/compiler-rs-linux-x64-musl@3.1.3':
     optional: true
 
-  '@vue-jsx-vapor/compiler-rs-wasm32-wasi@3.0.0':
+  '@vue-jsx-vapor/compiler-rs-wasm32-wasi@3.1.3':
     dependencies:
-      '@napi-rs/wasm-runtime': 1.0.7
+      '@napi-rs/wasm-runtime': 1.1.0
     optional: true
 
-  '@vue-jsx-vapor/compiler-rs-win32-arm64-msvc@3.0.0':
+  '@vue-jsx-vapor/compiler-rs-win32-arm64-msvc@3.1.3':
     optional: true
 
-  '@vue-jsx-vapor/compiler-rs-win32-ia32-msvc@3.0.0':
+  '@vue-jsx-vapor/compiler-rs-win32-ia32-msvc@3.1.3':
     optional: true
 
-  '@vue-jsx-vapor/compiler-rs-win32-x64-msvc@3.0.0':
+  '@vue-jsx-vapor/compiler-rs-win32-x64-msvc@3.1.3':
     optional: true
 
-  '@vue-jsx-vapor/compiler-rs@3.0.0':
+  '@vue-jsx-vapor/compiler-rs@3.1.3':
     optionalDependencies:
-      '@vue-jsx-vapor/compiler-rs-android-arm-eabi': 3.0.0
-      '@vue-jsx-vapor/compiler-rs-android-arm64': 3.0.0
-      '@vue-jsx-vapor/compiler-rs-darwin-arm64': 3.0.0
-      '@vue-jsx-vapor/compiler-rs-darwin-x64': 3.0.0
-      '@vue-jsx-vapor/compiler-rs-freebsd-x64': 3.0.0
-      '@vue-jsx-vapor/compiler-rs-linux-arm-gnueabihf': 3.0.0
-      '@vue-jsx-vapor/compiler-rs-linux-arm64-gnu': 3.0.0
-      '@vue-jsx-vapor/compiler-rs-linux-arm64-musl': 3.0.0
-      '@vue-jsx-vapor/compiler-rs-linux-x64-gnu': 3.0.0
-      '@vue-jsx-vapor/compiler-rs-linux-x64-musl': 3.0.0
-      '@vue-jsx-vapor/compiler-rs-wasm32-wasi': 3.0.0
-      '@vue-jsx-vapor/compiler-rs-win32-arm64-msvc': 3.0.0
-      '@vue-jsx-vapor/compiler-rs-win32-ia32-msvc': 3.0.0
-      '@vue-jsx-vapor/compiler-rs-win32-x64-msvc': 3.0.0
+      '@vue-jsx-vapor/compiler-rs-android-arm-eabi': 3.1.3
+      '@vue-jsx-vapor/compiler-rs-android-arm64': 3.1.3
+      '@vue-jsx-vapor/compiler-rs-darwin-arm64': 3.1.3
+      '@vue-jsx-vapor/compiler-rs-darwin-x64': 3.1.3
+      '@vue-jsx-vapor/compiler-rs-freebsd-x64': 3.1.3
+      '@vue-jsx-vapor/compiler-rs-linux-arm-gnueabihf': 3.1.3
+      '@vue-jsx-vapor/compiler-rs-linux-arm64-gnu': 3.1.3
+      '@vue-jsx-vapor/compiler-rs-linux-arm64-musl': 3.1.3
+      '@vue-jsx-vapor/compiler-rs-linux-x64-gnu': 3.1.3
+      '@vue-jsx-vapor/compiler-rs-linux-x64-musl': 3.1.3
+      '@vue-jsx-vapor/compiler-rs-wasm32-wasi': 3.1.3
+      '@vue-jsx-vapor/compiler-rs-win32-arm64-msvc': 3.1.3
+      '@vue-jsx-vapor/compiler-rs-win32-ia32-msvc': 3.1.3
+      '@vue-jsx-vapor/compiler-rs-win32-x64-msvc': 3.1.3
 
   '@vue-jsx-vapor/eslint@2.6.4(prettier@3.6.2)':
     dependencies:
@@ -6444,13 +6150,13 @@ snapshots:
     transitivePeerDependencies:
       - prettier
 
-  '@vue-jsx-vapor/macros@3.0.0(@nuxt/kit@3.17.6(magicast@0.3.5))(@nuxt/schema@3.17.6)(esbuild@0.25.9)(rolldown-vite@7.0.9(@types/node@22.18.1)(esbuild@0.25.9)(jiti@2.5.1)(sass@1.83.4)(terser@5.39.0)(tsx@4.19.2)(yaml@2.8.1))(rollup@4.50.0)(vue@3.6.0-alpha.2(typescript@5.9.2))':
+  '@vue-jsx-vapor/macros@3.1.3(@nuxt/kit@3.17.6(magicast@0.3.5))(@nuxt/schema@3.17.6)(esbuild@0.25.9)(rolldown-vite@7.0.9(@types/node@22.18.1)(esbuild@0.25.9)(jiti@2.5.1)(sass@1.83.4)(terser@5.39.0)(tsx@4.19.2)(yaml@2.8.1))(rollup@4.50.0)(vue@3.6.0-alpha.2(typescript@5.9.2))':
     dependencies:
       '@vue-macros/common': 3.1.1(vue@3.6.0-alpha.2(typescript@5.9.2))
-      '@vue/compiler-sfc': 3.6.0-alpha.2
+      '@vue/compiler-sfc': 3.6.0-alpha.7
       hash-sum: 2.0.0
       ts-macro: 0.3.6
-      unplugin: 2.3.10
+      unplugin: 2.3.11
     optionalDependencies:
       '@nuxt/kit': 3.17.6(magicast@0.3.5)
       '@nuxt/schema': 3.17.6
@@ -6460,7 +6166,7 @@ snapshots:
     transitivePeerDependencies:
       - vue
 
-  '@vue-jsx-vapor/runtime@3.0.0(vue@3.6.0-alpha.2(typescript@5.9.2))':
+  '@vue-jsx-vapor/runtime@3.1.3(vue@3.6.0-alpha.2(typescript@5.9.2))':
     dependencies:
       vue: 3.6.0-alpha.2(typescript@5.9.2)
 
@@ -6481,16 +6187,6 @@ snapshots:
     optionalDependencies:
       vue: 3.6.0-alpha.2(typescript@5.9.2)
 
-  '@vue-macros/common@3.1.1(vue@3.5.25(typescript@5.9.2))':
-    dependencies:
-      '@vue/compiler-sfc': 3.5.25
-      ast-kit: 2.1.2
-      local-pkg: 1.1.2
-      magic-string-ast: 1.0.2
-      unplugin-utils: 0.3.0
-    optionalDependencies:
-      vue: 3.5.25(typescript@5.9.2)
-
   '@vue-macros/common@3.1.1(vue@3.6.0-alpha.2(typescript@5.9.2))':
     dependencies:
       '@vue/compiler-sfc': 3.5.25
@@ -6508,14 +6204,6 @@ snapshots:
       unconfig: 7.3.3
     transitivePeerDependencies:
       - vue
-
-  '@vue-macros/jsx-directive@3.1.1(typescript@5.9.2)':
-    dependencies:
-      '@vue-macros/common': 3.1.1(vue@3.5.25(typescript@5.9.2))
-      unplugin: 2.3.10
-      vue: 3.5.25(typescript@5.9.2)
-    transitivePeerDependencies:
-      - typescript
 
   '@vue-macros/short-bind@3.1.1(vue@3.6.0-alpha.2(typescript@5.9.2))':
     dependencies:
@@ -6546,35 +6234,6 @@ snapshots:
       - typescript
       - vue
 
-  '@vue/babel-helper-vue-transform-on@1.5.0': {}
-
-  '@vue/babel-plugin-jsx@1.5.0(@babel/core@7.28.4)':
-    dependencies:
-      '@babel/helper-module-imports': 7.27.1
-      '@babel/helper-plugin-utils': 7.27.1
-      '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.28.4)
-      '@babel/template': 7.27.2
-      '@babel/traverse': 8.0.0-beta.2
-      '@babel/types': 7.28.5
-      '@vue/babel-helper-vue-transform-on': 1.5.0
-      '@vue/babel-plugin-resolve-type': 1.5.0(@babel/core@7.28.4)
-      '@vue/shared': 3.5.25
-    optionalDependencies:
-      '@babel/core': 7.28.4
-    transitivePeerDependencies:
-      - supports-color
-
-  '@vue/babel-plugin-resolve-type@1.5.0(@babel/core@7.28.4)':
-    dependencies:
-      '@babel/code-frame': 7.27.1
-      '@babel/core': 7.28.4
-      '@babel/helper-module-imports': 7.27.1
-      '@babel/helper-plugin-utils': 7.27.1
-      '@babel/parser': 7.28.5
-      '@vue/compiler-sfc': 3.5.25
-    transitivePeerDependencies:
-      - supports-color
-
   '@vue/compiler-core@3.5.17':
     dependencies:
       '@babel/parser': 7.28.4
@@ -6599,6 +6258,14 @@ snapshots:
       estree-walker: 2.0.2
       source-map-js: 1.2.1
 
+  '@vue/compiler-core@3.6.0-alpha.7':
+    dependencies:
+      '@babel/parser': 7.28.5
+      '@vue/shared': 3.6.0-alpha.7
+      entities: 4.5.0
+      estree-walker: 2.0.2
+      source-map-js: 1.2.1
+
   '@vue/compiler-dom@3.5.17':
     dependencies:
       '@vue/compiler-core': 3.5.17
@@ -6613,6 +6280,11 @@ snapshots:
     dependencies:
       '@vue/compiler-core': 3.6.0-alpha.2
       '@vue/shared': 3.6.0-alpha.2
+
+  '@vue/compiler-dom@3.6.0-alpha.7':
+    dependencies:
+      '@vue/compiler-core': 3.6.0-alpha.7
+      '@vue/shared': 3.6.0-alpha.7
 
   '@vue/compiler-sfc@3.5.17':
     dependencies:
@@ -6651,6 +6323,19 @@ snapshots:
       postcss: 8.5.6
       source-map-js: 1.2.1
 
+  '@vue/compiler-sfc@3.6.0-alpha.7':
+    dependencies:
+      '@babel/parser': 7.28.5
+      '@vue/compiler-core': 3.6.0-alpha.7
+      '@vue/compiler-dom': 3.6.0-alpha.7
+      '@vue/compiler-ssr': 3.6.0-alpha.7
+      '@vue/compiler-vapor': 3.6.0-alpha.7
+      '@vue/shared': 3.6.0-alpha.7
+      estree-walker: 2.0.2
+      magic-string: 0.30.21
+      postcss: 8.5.6
+      source-map-js: 1.2.1
+
   '@vue/compiler-ssr@3.5.17':
     dependencies:
       '@vue/compiler-dom': 3.5.17
@@ -6666,11 +6351,24 @@ snapshots:
       '@vue/compiler-dom': 3.6.0-alpha.2
       '@vue/shared': 3.6.0-alpha.2
 
+  '@vue/compiler-ssr@3.6.0-alpha.7':
+    dependencies:
+      '@vue/compiler-dom': 3.6.0-alpha.7
+      '@vue/shared': 3.6.0-alpha.7
+
   '@vue/compiler-vapor@3.6.0-alpha.2':
     dependencies:
       '@babel/parser': 7.28.4
       '@vue/compiler-dom': 3.6.0-alpha.2
       '@vue/shared': 3.6.0-alpha.2
+      estree-walker: 2.0.2
+      source-map-js: 1.2.1
+
+  '@vue/compiler-vapor@3.6.0-alpha.7':
+    dependencies:
+      '@babel/parser': 7.28.5
+      '@vue/compiler-dom': 3.6.0-alpha.7
+      '@vue/shared': 3.6.0-alpha.7
       estree-walker: 2.0.2
       source-map-js: 1.2.1
 
@@ -6705,30 +6403,14 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.2
 
-  '@vue/reactivity@3.5.25':
-    dependencies:
-      '@vue/shared': 3.5.25
-
   '@vue/reactivity@3.6.0-alpha.2':
     dependencies:
       '@vue/shared': 3.6.0-alpha.2
-
-  '@vue/runtime-core@3.5.25':
-    dependencies:
-      '@vue/reactivity': 3.5.25
-      '@vue/shared': 3.5.25
 
   '@vue/runtime-core@3.6.0-alpha.2':
     dependencies:
       '@vue/reactivity': 3.6.0-alpha.2
       '@vue/shared': 3.6.0-alpha.2
-
-  '@vue/runtime-dom@3.5.25':
-    dependencies:
-      '@vue/reactivity': 3.5.25
-      '@vue/runtime-core': 3.5.25
-      '@vue/shared': 3.5.25
-      csstype: 3.1.3
 
   '@vue/runtime-dom@3.6.0-alpha.2':
     dependencies:
@@ -6743,12 +6425,6 @@ snapshots:
       '@vue/runtime-dom': 3.6.0-alpha.2
       '@vue/shared': 3.6.0-alpha.2
 
-  '@vue/server-renderer@3.5.25(vue@3.5.25(typescript@5.9.2))':
-    dependencies:
-      '@vue/compiler-ssr': 3.5.25
-      '@vue/shared': 3.5.25
-      vue: 3.5.25(typescript@5.9.2)
-
   '@vue/server-renderer@3.6.0-alpha.2(vue@3.6.0-alpha.2(typescript@5.9.2))':
     dependencies:
       '@vue/compiler-ssr': 3.6.0-alpha.2
@@ -6760,6 +6436,8 @@ snapshots:
   '@vue/shared@3.5.25': {}
 
   '@vue/shared@3.6.0-alpha.2': {}
+
+  '@vue/shared@3.6.0-alpha.7': {}
 
   '@whatwg-node/disposablestack@0.0.6':
     dependencies:
@@ -6966,13 +6644,6 @@ snapshots:
     dependencies:
       fill-range: 7.1.1
 
-  browserslist@4.25.4:
-    dependencies:
-      caniuse-lite: 1.0.30001741
-      electron-to-chromium: 1.5.214
-      node-releases: 2.0.20
-      update-browserslist-db: 1.1.3(browserslist@4.25.4)
-
   buffer-crc32@1.0.0: {}
 
   buffer-from@1.1.2: {}
@@ -7065,8 +6736,6 @@ snapshots:
     optional: true
 
   callsites@3.1.0: {}
-
-  caniuse-lite@1.0.30001741: {}
 
   ccount@2.0.1: {}
 
@@ -7252,8 +6921,6 @@ snapshots:
     dependencies:
       meow: 13.2.0
 
-  convert-source-map@2.0.0: {}
-
   cookie-es@1.2.2: {}
 
   cookie-es@2.0.0: {}
@@ -7395,8 +7062,6 @@ snapshots:
     dependencies:
       '@standard-schema/spec': 1.0.0
       fast-check: 3.23.2
-
-  electron-to-chromium@1.5.214: {}
 
   emoji-regex@10.4.0: {}
 
@@ -7713,8 +7378,6 @@ snapshots:
   generic-names@4.0.0:
     dependencies:
       loader-utils: 3.3.1
-
-  gensync@1.0.0-beta.2: {}
 
   get-caller-file@2.0.5: {}
 
@@ -8057,8 +7720,6 @@ snapshots:
 
   json-stable-stringify-without-jsonify@1.0.1: {}
 
-  json5@2.2.3: {}
-
   jsonc-parser@3.3.1: {}
 
   jsonfile@6.1.0:
@@ -8230,10 +7891,6 @@ snapshots:
       wrap-ansi: 9.0.0
 
   lru-cache@10.4.3: {}
-
-  lru-cache@5.1.1:
-    dependencies:
-      yallist: 3.1.1
 
   lru-cache@6.0.0:
     dependencies:
@@ -8546,8 +8203,6 @@ snapshots:
   node-gyp-build@4.8.4: {}
 
   node-mock-http@1.0.3: {}
-
-  node-releases@2.0.20: {}
 
   nopt@8.1.0:
     dependencies:
@@ -9101,8 +8756,6 @@ snapshots:
     optional: true
 
   scule@1.3.0: {}
-
-  semver@6.3.1: {}
 
   semver@7.5.4:
     dependencies:
@@ -9685,6 +9338,13 @@ snapshots:
       picomatch: 4.0.3
       webpack-virtual-modules: 0.6.2
 
+  unplugin@2.3.11:
+    dependencies:
+      '@jridgewell/remapping': 2.3.5
+      acorn: 8.15.0
+      picomatch: 4.0.3
+      webpack-virtual-modules: 0.6.2
+
   unplugin@2.3.5:
     dependencies:
       acorn: 8.14.1
@@ -9728,12 +9388,6 @@ snapshots:
       pathe: 2.0.3
       pkg-types: 2.3.0
       unplugin: 2.3.10
-
-  update-browserslist-db@1.1.3(browserslist@4.25.4):
-    dependencies:
-      browserslist: 4.25.4
-      escalade: 3.2.0
-      picocolors: 1.1.1
 
   uqr@0.1.2: {}
 
@@ -9851,21 +9505,16 @@ snapshots:
 
   vue-flow-layout@0.2.0: {}
 
-  vue-jsx-vapor@3.0.0(@nuxt/kit@3.17.6(magicast@0.3.5))(@nuxt/schema@3.17.6)(esbuild@0.25.9)(rolldown-vite@7.0.9(@types/node@22.18.1)(esbuild@0.25.9)(jiti@2.5.1)(sass@1.83.4)(terser@5.39.0)(tsx@4.19.2)(yaml@2.8.1))(rollup@4.50.0)(typescript@5.9.2)(vue@3.6.0-alpha.2(typescript@5.9.2)):
+  vue-jsx-vapor@3.1.3(@nuxt/kit@3.17.6(magicast@0.3.5))(@nuxt/schema@3.17.6)(esbuild@0.25.9)(rolldown-vite@7.0.9(@types/node@22.18.1)(esbuild@0.25.9)(jiti@2.5.1)(sass@1.83.4)(terser@5.39.0)(tsx@4.19.2)(yaml@2.8.1))(rollup@4.50.0)(typescript@5.9.2)(vue@3.6.0-alpha.2(typescript@5.9.2)):
     dependencies:
-      '@babel/core': 7.28.4
-      '@babel/plugin-transform-typescript': 7.28.0(@babel/core@7.28.4)
-      '@vue-jsx-vapor/compiler-rs': 3.0.0
-      '@vue-jsx-vapor/macros': 3.0.0(@nuxt/kit@3.17.6(magicast@0.3.5))(@nuxt/schema@3.17.6)(esbuild@0.25.9)(rolldown-vite@7.0.9(@types/node@22.18.1)(esbuild@0.25.9)(jiti@2.5.1)(sass@1.83.4)(terser@5.39.0)(tsx@4.19.2)(yaml@2.8.1))(rollup@4.50.0)(vue@3.6.0-alpha.2(typescript@5.9.2))
-      '@vue-jsx-vapor/runtime': 3.0.0(vue@3.6.0-alpha.2(typescript@5.9.2))
-      '@vue-macros/jsx-directive': 3.1.1(typescript@5.9.2)
+      '@vue-jsx-vapor/compiler-rs': 3.1.3
+      '@vue-jsx-vapor/macros': 3.1.3(@nuxt/kit@3.17.6(magicast@0.3.5))(@nuxt/schema@3.17.6)(esbuild@0.25.9)(rolldown-vite@7.0.9(@types/node@22.18.1)(esbuild@0.25.9)(jiti@2.5.1)(sass@1.83.4)(terser@5.39.0)(tsx@4.19.2)(yaml@2.8.1))(rollup@4.50.0)(vue@3.6.0-alpha.2(typescript@5.9.2))
+      '@vue-jsx-vapor/runtime': 3.1.3(vue@3.6.0-alpha.2(typescript@5.9.2))
       '@vue-macros/volar': 3.1.1(typescript@5.9.2)(vue@3.6.0-alpha.2(typescript@5.9.2))
-      '@vue/babel-plugin-jsx': 1.5.0(@babel/core@7.28.4)
-      '@vue/shared': 3.6.0-alpha.2
-      hash-sum: 2.0.0
+      '@vue/shared': 3.6.0-alpha.7
       pathe: 2.0.3
       ts-macro: 0.3.6
-      unplugin: 2.3.10
+      unplugin: 2.3.11
       unplugin-utils: 0.2.5
       vue: 3.6.0-alpha.2(typescript@5.9.2)
     optionalDependencies:
@@ -9875,23 +9524,12 @@ snapshots:
       rollup: 4.50.0
       vite: rolldown-vite@7.0.9(@types/node@22.18.1)(esbuild@0.25.9)(jiti@2.5.1)(sass@1.83.4)(terser@5.39.0)(tsx@4.19.2)(yaml@2.8.1)
     transitivePeerDependencies:
-      - supports-color
       - typescript
       - vue-tsc
 
   vue-resize@2.0.0-alpha.1(vue@3.6.0-alpha.2(typescript@5.9.2)):
     dependencies:
       vue: 3.6.0-alpha.2(typescript@5.9.2)
-
-  vue@3.5.25(typescript@5.9.2):
-    dependencies:
-      '@vue/compiler-dom': 3.5.25
-      '@vue/compiler-sfc': 3.5.25
-      '@vue/runtime-dom': 3.5.25
-      '@vue/server-renderer': 3.5.25(vue@3.5.25(typescript@5.9.2))
-      '@vue/shared': 3.5.25
-    optionalDependencies:
-      typescript: 5.9.2
 
   vue@3.6.0-alpha.2(typescript@5.9.2):
     dependencies:
@@ -9965,8 +9603,6 @@ snapshots:
       is-wsl: 3.1.0
 
   y18n@5.0.8: {}
-
-  yallist@3.1.1: {}
 
   yallist@4.0.0: {}
 


### PR DESCRIPTION
Thank you so much for your amazing work on vue-jsx-vapor! 🎉 
I've updated the dependency to version 3.1.0 to try out the latest features. 
I'd love to experiment with it in the playground as well!